### PR TITLE
Gh action to auto create a new PR with updated documentation

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -3,9 +3,10 @@ name: generate-terraform-docs
 on:
   push:
     branches:
-      - test-gh-action
+      - generate-terraform-docs-test-branch
     paths:
       - '**.tf'
+
 jobs:
   tf-docs:
     name: TF docs

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -38,7 +38,6 @@ jobs:
           title: 'generate-terraform-docs: automated action'
           body: |
             Update terraform docs
-          branch: ${{ steps.git-branch.outputs.generated_branch }}
           branch-suffix: timestamp
           base: main
           signoff: true

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -21,9 +21,7 @@ jobs:
         id: terraform-docs
         uses: terraform-docs/gh-actions@v1.0.0
         with:
-          working-dir: .,examples
-          recursive: true
-          recursive-path: modules
+          find-dir: .
           args: --sort-by required
           indention: 3
           git-push: "false"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -3,7 +3,7 @@ name: generate-terraform-docs
 on:
   push:
     branches:
-      - generate-terraform-docs-test-branch
+      - main
     paths:
       - '**.tf'
 
@@ -15,15 +15,16 @@ jobs:
       - uses: actions/checkout@v3
         id: actions-checkout
         with:
-          ref: docs
+          ref: main
 
       - id: git-branch
         run: |
           generated_branch="update-docs-$(date +%s)"
           echo "generated_branch=${generated_branch}" >>$GITHUB_OUTPUT
           git checkout -b $generated_branch
+          git push --set-upstream origin $generated_branch
 
-      - name: Render terraform docs inside main and modules README.md files and push changes back to PR branch
+      - name: Render terraform docs inside the main and the modules README.md files and push changes back to PR branch
         id: terraform-docs
         uses: terraform-docs/gh-actions@v1.0.0
         with:
@@ -32,15 +33,22 @@ jobs:
           recursive-path: modules
           args: --sort-by required
           indention: 3
-          git-push: "true"
-          git-commit-message: "terraform-docs: automated action"
-          git-push-sign-off: "true"
+          git-push: "false"
 
       - name: Create Pull Request
         if: steps.terraform-docs.outputs.num_changed != '0'
         uses: peter-evans/create-pull-request@v4
         with:
+          commit-message: 'generate-terraform-docs: automated action'
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           title: 'generate-terraform-docs: automated action'
+          body: |
+            Update terraform docs
+          branch: ${{ steps.git-branch.outputs.generated_branch }}
+          base: main
+          signoff: true
+          delete-branch: true
 
       # TODO(ocobleseqx): https://github.com/peter-evans/enable-pull-request-automerge
 
@@ -48,4 +56,6 @@ jobs:
         if: steps.terraform-docs.outputs.num_changed == '0'
         run: |
           git checkout main
+          git push origin --delete ${{ steps.git-branch.outputs.generated_branch }}
+          git fetch -p
           git branch -D ${{ steps.git-branch.outputs.generated_branch }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,6 +15,8 @@ jobs:
         id: actions-checkout
         with:
           ref: docs
+
+      - id: git-branch
         run: |
           generated_branch="update-docs-$(date +%s)"
           echo "generated_branch=${generated_branch}" >>$GITHUB_OUTPUT
@@ -45,4 +47,4 @@ jobs:
         if: steps.terraform-docs.outputs.num_changed == '0'
         run: |
           git checkout main
-          git branch -D ${{ steps.actions-checkout.outputs.generated_branch }}
+          git branch -D ${{ steps.git-branch.outputs.generated_branch }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -21,7 +21,7 @@ jobs:
         id: terraform-docs
         uses: terraform-docs/gh-actions@v1.0.0
         with:
-          working-dir: .
+          working-dir: .,examples
           recursive: true
           recursive-path: modules
           args: --sort-by required

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,21 +1,26 @@
-name: Generate terraform docs
+name: generate-terraform-docs
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
+      - test-gh-action
     paths:
       - '**.tf'
-      - '**.md'
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      id: actions-checkout
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: docs
+      - run: |
+          generated_branch="update-docs-$(date +%s)"
+          echo "generated_branch=${generated_branch}" >>$GITHUB_OUTPUT
+          git checkout -b $generated_branch
 
     - name: Render terraform docs inside main and modules README.md files and push changes back to PR branch
+      id: terraform-docs
       uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .
@@ -25,3 +30,18 @@ jobs:
         indention: 3
         git-push: "true"
         git-commit-message: "terraform-docs: automated action"
+        git-push-sign-off: "true"
+
+    - name: Create Pull Request
+      if: ${{ steps.terraform-docs.outputs.num_changed != '0' }}
+      uses: peter-evans/create-pull-request@v4
+      with:
+        title: 'generate-terraform-docs: automated action'
+
+    # TODO(ocobleseqx): https://github.com/peter-evans/enable-pull-request-automerge
+
+    - name: Delete branch
+      if: ${{ steps.terraform-docs.outputs.num_changed == '0' }}
+      run: |
+        git checkout main
+        git branch -D ${{ steps.actions-checkout.outputs.generated_branch }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,13 +17,6 @@ jobs:
         with:
           ref: main
 
-      - id: git-branch
-        run: |
-          generated_branch="update-docs-$(date +%s)"
-          echo "generated_branch=${generated_branch}" >>$GITHUB_OUTPUT
-          git checkout -b $generated_branch
-          git push --set-upstream origin $generated_branch
-
       - name: Render terraform docs inside the main and the modules README.md files and push changes back to PR branch
         id: terraform-docs
         uses: terraform-docs/gh-actions@v1.0.0
@@ -46,16 +39,9 @@ jobs:
           body: |
             Update terraform docs
           branch: ${{ steps.git-branch.outputs.generated_branch }}
+          branch-suffix: timestamp
           base: main
           signoff: true
           delete-branch: true
 
       # TODO(ocobleseqx): https://github.com/peter-evans/enable-pull-request-automerge
-
-      - name: Delete branch
-        if: steps.terraform-docs.outputs.num_changed == '0'
-        run: |
-          git checkout main
-          git push origin --delete ${{ steps.git-branch.outputs.generated_branch }}
-          git fetch -p
-          git branch -D ${{ steps.git-branch.outputs.generated_branch }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -7,41 +7,42 @@ on:
     paths:
       - '**.tf'
 jobs:
-  docs:
+  tf-docs:
+    name: TF docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      id: actions-checkout
-      with:
-        ref: docs
-      - run: |
+      - uses: actions/checkout@v3
+        id: actions-checkout
+        with:
+          ref: docs
+        run: |
           generated_branch="update-docs-$(date +%s)"
           echo "generated_branch=${generated_branch}" >>$GITHUB_OUTPUT
           git checkout -b $generated_branch
 
-    - name: Render terraform docs inside main and modules README.md files and push changes back to PR branch
-      id: terraform-docs
-      uses: terraform-docs/gh-actions@v1.0.0
-      with:
-        working-dir: .
-        recursive: true
-        recursive-path: modules
-        args: --sort-by required
-        indention: 3
-        git-push: "true"
-        git-commit-message: "terraform-docs: automated action"
-        git-push-sign-off: "true"
+      - name: Render terraform docs inside main and modules README.md files and push changes back to PR branch
+        id: terraform-docs
+        uses: terraform-docs/gh-actions@v1.0.0
+        with:
+          working-dir: .
+          recursive: true
+          recursive-path: modules
+          args: --sort-by required
+          indention: 3
+          git-push: "true"
+          git-commit-message: "terraform-docs: automated action"
+          git-push-sign-off: "true"
 
-    - name: Create Pull Request
-      if: ${{ steps.terraform-docs.outputs.num_changed != '0' }}
-      uses: peter-evans/create-pull-request@v4
-      with:
-        title: 'generate-terraform-docs: automated action'
+      - name: Create Pull Request
+        if: steps.terraform-docs.outputs.num_changed != '0'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: 'generate-terraform-docs: automated action'
 
-    # TODO(ocobleseqx): https://github.com/peter-evans/enable-pull-request-automerge
+      # TODO(ocobleseqx): https://github.com/peter-evans/enable-pull-request-automerge
 
-    - name: Delete branch
-      if: ${{ steps.terraform-docs.outputs.num_changed == '0' }}
-      run: |
-        git checkout main
-        git branch -D ${{ steps.actions-checkout.outputs.generated_branch }}
+      - name: Delete branch
+        if: steps.terraform-docs.outputs.num_changed == '0'
+        run: |
+          git checkout main
+          git branch -D ${{ steps.actions-checkout.outputs.generated_branch }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Config Terraform plugin cache
-        if: steps.changes.outputs.src== 'true'
         run: |
           echo 'plugin_cache_dir="$HOME/.terraform.d/plugin-cache"' >~/.terraformrc
           mkdir --parents ~/.terraform.d/plugin-cache
@@ -46,7 +45,6 @@ jobs:
 
       - name: Pre-commit Terraform ${{ env.TERRAFORM_VERSION }}
         uses: ./pre-commit
-        if: steps.changes.outputs.src== 'true'
         with:
           terraform-version: ${{ env.TERRAFORM_VERSION }}
           tflint-version: ${{ env.TFLINT_VERSION }}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Terraform Equinix Kubernetes Addons - Blueprints
+
+//TODO


### PR DESCRIPTION
With the version already merged in main, we were getting a 403 error when the PR was created from a fork, since it doesn't have permissions to commit in the forked project.

With this new approach, no documentation is generated during the PR, and it is just after merging into main that it will generate the documentation if there are changes in any `.tf` file. Using a new temporary branch cloned from main it will create a new PR just for documentation.

I left a TODO comment with an auto-merge option that might be evaluated in the future.