### PR TITLE
Add ConfigMap for MetalLB

### DIFF
--- a/modules/metallb/templates/config.yaml.tftpl
+++ b/modules/metallb/templates/config.yaml.tftpl
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data: {}
+---
 apiVersion: metallb.io/v1beta2
 kind: BGPPeer
 metadata:


### PR DESCRIPTION
Cloud Provider Equinix Metal needs this ConfigMap to exist in orderto tell MetalLB what IPs to use.