### PR TITLE
Enable rook cluster creation in rook module

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ No resources.
 | <a name="input_equinix_project"></a> [equinix\_project](#input\_equinix\_project) | Equinix project | `string` | n/a | yes |
 | <a name="input_kubeconfig_local_path"></a> [kubeconfig\_local\_path](#input\_kubeconfig\_local\_path) | Depending on your setup, you may need to specify the path to the kubeconfig file locally | `string` | n/a | yes |
 | <a name="input_kubeconfig_remote_path"></a> [kubeconfig\_remote\_path](#input\_kubeconfig\_remote\_path) | Depending on your setup, you may need to specify the path to the kubeconfig file hosted on the remote server | `string` | n/a | yes |
-| <a name="input_longhorn_config"></a> [longhorn\_config](#input\_longhorn\_config) | Configuration for Longhorn add-on | `any` | n/a | yes |
-| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Configuration for Rook add-on | `any` | n/a | yes |
 | <a name="input_ssh_host"></a> [ssh\_host](#input\_ssh\_host) | The address of the server from where to perform kubectl installations and changes | `string` | n/a | yes |
 | <a name="input_ssh_private_key"></a> [ssh\_private\_key](#input\_ssh\_private\_key) | The contents of an SSH key to use for the connection. These can be loaded from a file on disk using the file function | `string` | n/a | yes |
 | <a name="input_enable_longhorn"></a> [enable\_longhorn](#input\_enable\_longhorn) | Enable Longhorn add-on | `bool` | `false` | no |
 | <a name="input_enable_metallb"></a> [enable\_metallb](#input\_enable\_metallb) | Enable Metallb add-on | `bool` | `false` | no |
 | <a name="input_enable_rook"></a> [enable\_rook](#input\_enable\_rook) | Enable Rook add-on | `bool` | `false` | no |
+| <a name="input_longhorn_config"></a> [longhorn\_config](#input\_longhorn\_config) | Configuration for Longhorn add-on | `any` | `null` | no |
 | <a name="input_metallb_config"></a> [metallb\_config](#input\_metallb\_config) | Configuration for Metallb add-on | `any` | `{}` | no |
+| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Configuration for Rook add-on | `any` | `null` | no |
 | <a name="input_ssh_user"></a> [ssh\_user](#input\_ssh\_user) | The user to use for the connection | `string` | `"root"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `['k8s`,`production`] | `list(string)` | `[]` | no |
 

--- a/modules/rook/README.md
+++ b/modules/rook/README.md
@@ -67,13 +67,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [helm_release.rook](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.rook-ceph](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.rook-ceph-cluster](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook_name": "rook-ceph",<br>  "rook_namespace": "rook-ceph"<br>}</pre> | no |
+| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook-ceph-cluster_name": "rook-ceph-cluster",<br>  "rook-ceph-cluster_namespace": "rook-ceph",<br>  "rook-ceph_name": "rook-ceph",<br>  "rook-ceph_namespace": "rook-ceph"<br>}</pre> | no |
 
 ### Outputs
 

--- a/modules/rook/README.md
+++ b/modules/rook/README.md
@@ -2,7 +2,7 @@
 
 Rook is an open source cloud-native storage orchestrator, providing the platform, framework, and support for Ceph storage to natively integrate with cloud-native environments.
 
-This module installs rook using the rook-ceph helm chart.
+This module installs rook using the rook_ceph helm chart.
 
 Please note this the default rook cluster installed by this module requires three worker nodes to actually come up.
 
@@ -39,7 +39,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook_name": "rook-ceph",<br>  "rook_namespace": "rook-ceph"<br>}</pre> | no |
+| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook_name": "rook_ceph",<br>  "rook_namespace": "rook_ceph"<br>}</pre> | no |
 
 ## Outputs
 
@@ -69,14 +69,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [helm_release.rook-ceph](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [helm_release.rook-ceph-cluster](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.rook_ceph](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.rook_ceph_cluster](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook-ceph-cluster_name": "rook-ceph-cluster",<br>  "rook-ceph-cluster_namespace": "rook-ceph",<br>  "rook-ceph_name": "rook-ceph",<br>  "rook-ceph_namespace": "rook-ceph"<br>}</pre> | no |
+| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook_ceph_cluster_name": "rook_ceph_cluster",<br>  "rook_ceph_cluster_namespace": "rook_ceph",<br>  "rook_ceph_name": "rook_ceph",<br>  "rook_ceph_namespace": "rook_ceph"<br>}</pre> | no |
 
 ### Outputs
 

--- a/modules/rook/README.md
+++ b/modules/rook/README.md
@@ -76,7 +76,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook_ceph_cluster_name": "rook_ceph_cluster",<br>  "rook_ceph_cluster_namespace": "rook_ceph",<br>  "rook_ceph_name": "rook_ceph",<br>  "rook_ceph_namespace": "rook_ceph"<br>}</pre> | no |
+| <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook_ceph_cluster_name": "rook-ceph-cluster",<br>  "rook_ceph_cluster_namespace": "rook-ceph",<br>  "rook_ceph_name": "rook-ceph",<br>  "rook_ceph_namespace": "rook-ceph"<br>}</pre> | no |
 
 ### Outputs
 

--- a/modules/rook/README.md
+++ b/modules/rook/README.md
@@ -4,6 +4,8 @@ Rook is an open source cloud-native storage orchestrator, providing the platform
 
 This module installs rook using the rook-ceph helm chart.
 
+Please note this the default rook cluster installed by this module requires three worker nodes to actually come up.
+
 For more details checkout [Rook](https://rook.github.io/docs/rook/latest-release/Getting-Started/intro/) docs.
 
 <!-- TEMPLATE: Insert an image here of the infrastructure diagram. You can generate a starting image using instructions found at https://www.terraform.io/docs/cli/commands/graph.html#generating-images -->

--- a/modules/rook/examples/simple/main.tf
+++ b/modules/rook/examples/simple/main.tf
@@ -22,5 +22,5 @@ module "equinix_kubernetes_addons" {
   }
 }
 provider "equinix" {
-  auth_token = var.auth_token
+  auth_token = var.metal_auth_token
 }

--- a/modules/rook/examples/simple/main.tf
+++ b/modules/rook/examples/simple/main.tf
@@ -15,10 +15,10 @@ module "equinix_kubernetes_addons" {
 
   enable_rook = true
   rook_config = {
-    rook-ceph_name              = "rook-ceph"
-    rook-ceph_namespace         = "rook-ceph"
-    rook-ceph-cluster_name      = "rook-ceph-cluster"
-    rook-ceph-cluster_namespace = "rook-ceph"
+    rook_ceph_name              = "rook-ceph"
+    rook_ceph_namespace         = "rook-ceph"
+    rook_ceph_cluster_name      = "rook-ceph-cluster"
+    rook_ceph_cluster_namespace = "rook-ceph"
   }
 }
 provider "equinix" {

--- a/modules/rook/examples/simple/main.tf
+++ b/modules/rook/examples/simple/main.tf
@@ -15,8 +15,10 @@ module "equinix_kubernetes_addons" {
 
   enable_rook = true
   rook_config = {
-    rook_name      = "rook-ceph"
-    rook_namespace = "rook-ceph"
+    rook-ceph_name              = "rook-ceph"
+    rook-ceph_namespace         = "rook-ceph"
+    rook-ceph-cluster_name      = "rook-ceph-cluster"
+    rook-ceph-cluster_namespace = "rook-ceph"
   }
 }
 provider "equinix" {

--- a/modules/rook/examples/simple/variables.tf
+++ b/modules/rook/examples/simple/variables.tf
@@ -1,4 +1,4 @@
-variable "auth_token" {
+variable "metal_auth_token" {
   type        = string
   description = "Equinix Metal API key"
   sensitive   = true

--- a/modules/rook/main.tf
+++ b/modules/rook/main.tf
@@ -7,9 +7,9 @@
 # TEMPLATE: When main.tf becomes unwieldy, consider submodules (https://www.terraform.io/docs/language/modules/develop/structure.html) 
 # TEMPLATE: and dependency inversion (https://www.terraform.io/docs/language/modules/develop/composition.html).
 
-resource "helm_release" "rook" {
-  name             = var.rook_config.rook_name
-  namespace        = var.rook_config.rook_namespace
+resource "helm_release" "rook-ceph" {
+  name             = var.rook_config.rook-ceph_name
+  namespace        = var.rook_config.rook-ceph_namespace
   create_namespace = true
   repository       = "https://charts.rook.io/release"
   chart            = "rook-ceph"
@@ -19,4 +19,16 @@ resource "helm_release" "rook" {
    set {
   defaultSettings.taintToleration  = "key1=value1:NoSchedule; key2:NoExecute"
   } */
+}
+resource "helm_release" "rook-ceph-cluster" {
+  name             = var.rook_config.rook-ceph-cluster_name
+  namespace        = var.rook_config.rook-ceph-cluster_namespace
+  create_namespace = true
+  repository       = "https://charts.rook.io/release"
+  chart            = "rook-ceph-cluster"
+
+  set {
+    name  = "operatorNamespace"
+    value = var.rook_config.rook-ceph_namespace
+  }
 }

--- a/modules/rook/main.tf
+++ b/modules/rook/main.tf
@@ -7,23 +7,23 @@
 # TEMPLATE: When main.tf becomes unwieldy, consider submodules (https://www.terraform.io/docs/language/modules/develop/structure.html) 
 # TEMPLATE: and dependency inversion (https://www.terraform.io/docs/language/modules/develop/composition.html).
 
-resource "helm_release" "rook-ceph" {
-  name             = var.rook_config.rook-ceph_name
-  namespace        = var.rook_config.rook-ceph_namespace
+resource "helm_release" "rook_ceph" {
+  name             = var.rook_config.rook_ceph_name
+  namespace        = var.rook_config.rook_ceph_namespace
   create_namespace = true
   repository       = "https://charts.rook.io/release"
-  chart            = "rook-ceph"
+  chart            = "rook_ceph"
 
 }
-resource "helm_release" "rook-ceph-cluster" {
-  name             = var.rook_config.rook-ceph-cluster_name
-  namespace        = var.rook_config.rook-ceph-cluster_namespace
+resource "helm_release" "rook_ceph_cluster" {
+  name             = var.rook_config.rook_ceph_cluster_name
+  namespace        = var.rook_config.rook_ceph_cluster_namespace
   create_namespace = true
   repository       = "https://charts.rook.io/release"
-  chart            = "rook-ceph-cluster"
+  chart            = "rook_ceph_cluster"
 
   set {
     name  = "operatorNamespace"
-    value = var.rook_config.rook-ceph_namespace
+    value = var.rook_config.rook_ceph_namespace
   }
 }

--- a/modules/rook/main.tf
+++ b/modules/rook/main.tf
@@ -12,7 +12,7 @@ resource "helm_release" "rook_ceph" {
   namespace        = var.rook_config.rook_ceph_namespace
   create_namespace = true
   repository       = "https://charts.rook.io/release"
-  chart            = "rook_ceph"
+  chart            = "rook-ceph"
 
 }
 resource "helm_release" "rook_ceph_cluster" {
@@ -20,7 +20,7 @@ resource "helm_release" "rook_ceph_cluster" {
   namespace        = var.rook_config.rook_ceph_cluster_namespace
   create_namespace = true
   repository       = "https://charts.rook.io/release"
-  chart            = "rook_ceph_cluster"
+  chart            = "rook-ceph-cluster"
 
   set {
     name  = "operatorNamespace"

--- a/modules/rook/main.tf
+++ b/modules/rook/main.tf
@@ -14,11 +14,6 @@ resource "helm_release" "rook-ceph" {
   repository       = "https://charts.rook.io/release"
   chart            = "rook-ceph"
 
-
-  /*  #Set overrides here  
-   set {
-  defaultSettings.taintToleration  = "key1=value1:NoSchedule; key2:NoExecute"
-  } */
 }
 resource "helm_release" "rook-ceph-cluster" {
   name             = var.rook_config.rook-ceph-cluster_name

--- a/modules/rook/variables.tf
+++ b/modules/rook/variables.tf
@@ -11,7 +11,9 @@ variable "rook_config" {
   description = "Add-on configuration for Rook add-on"
   type        = any
   default = {
-    rook_name      = "rook-ceph"
-    rook_namespace = "rook-ceph"
+    rook-ceph_name              = "rook-ceph"
+    rook-ceph_namespace         = "rook-ceph"
+    rook-ceph-cluster_name      = "rook-ceph-cluster"
+    rook-ceph-cluster_namespace = "rook-ceph"
   }
 }

--- a/modules/rook/variables.tf
+++ b/modules/rook/variables.tf
@@ -11,9 +11,9 @@ variable "rook_config" {
   description = "Add-on configuration for Rook add-on"
   type        = any
   default = {
-    rook-ceph_name              = "rook-ceph"
-    rook-ceph_namespace         = "rook-ceph"
-    rook-ceph-cluster_name      = "rook-ceph-cluster"
-    rook-ceph-cluster_namespace = "rook-ceph"
+    rook_ceph_name              = "rook-ceph"
+    rook_ceph_namespace         = "rook-ceph"
+    rook_ceph_cluster_name      = "rook-ceph-cluster"
+    rook_ceph_cluster_namespace = "rook-ceph"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,7 @@ variable "enable_longhorn" {
 variable "longhorn_config" {
   type        = any
   description = "Configuration for Longhorn add-on"
+  default     = null
 }
 
 variable "enable_rook" {
@@ -29,6 +30,7 @@ variable "enable_rook" {
 variable "rook_config" {
   type        = any
   description = "Configuration for Rook add-on"
+  default     = null
 }
 
 variable "ssh_host" {


### PR DESCRIPTION
This change enables the rook-ceph-cluster helm chart and sets it up to make a default cluster.

It should be noted this cluster requires 3 worker nodes before it will start.