### PR TITLE
Added TF_DOCS required delimiters to all modules

### DIFF
--- a/modules/cloud_provider_equinix_metal/README.md
+++ b/modules/cloud_provider_equinix_metal/README.md
@@ -7,44 +7,7 @@ This is a Terraform module that installs and configures Cloud Provider Equinix M
 
 <!-- TEMPLATE: Insert an image here of the infrastructure diagram. You can generate a starting image using instructions found at https://www.terraform.io/docs/cli/commands/graph.html#generating-images -->
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
-
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [null_resource.install_cloud_provider_equinix_metal](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_addon_config"></a> [addon\_config](#input\_addon\_config) | Add-on configuration for Cloud Provider Equinix Metal | <pre>object({<br>     version = string<br>     secret  = map(string)<br>  }) | N/A | yes |
-| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input context for the addon | <pre>object({<br>    equinix_project        = string<br>    equinix_metro          = string<br>    kubeconfig_remote_path = string<br>  })</pre> | n/a | yes |
-| <a name="input_ssh_config"></a> [ssh\_config](#input\_ssh\_config) | Connection details to apply configuration | <pre>object({<br>    host        = string<br>    user        = optional(string)<br>    private_key = string<br>  })</pre> | n/a | yes |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="prerequisites"></a> [prerequisites](#output\_prerequisites) | cloud-init configuration that must be run on nodes when they are provisioned.  Must be a list of objects conforming to the [`part` schema documented for the `cloudinit_config` resource](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/cloudinit_config) |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
+<!-- TEMPLATE: Please do not remove BEGIN_TF_DOCS/END_TF_DOCS comments below -->
 <!-- BEGIN_TF_DOCS -->
 ### Requirements
 

--- a/modules/cloud_provider_equinix_metal/examples/simple/README.md
+++ b/modules/cloud_provider_equinix_metal/examples/simple/README.md
@@ -19,3 +19,7 @@ cd terraform-equinix-kubernetes-addons/modules/cloudproviderequinixmetal/example
 terraform init
 terraform apply
 ```
+
+<!-- TEMPLATE: Please do not remove BEGIN_TF_DOCS/END_TF_DOCS comments below -->
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/modules/longhorn/README.md
+++ b/modules/longhorn/README.md
@@ -6,42 +6,7 @@ For more details checkout [Longhorn](https://longhorn.io/docs/) docs.
 
 <!-- TEMPLATE: Insert an image here of the infrastructure diagram. You can generate a starting image using instructions found at https://www.terraform.io/docs/cli/commands/graph.html#generating-images -->
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_equinix"></a> [equinix](#requirement\_equinix) | >= 1.11.1 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.8.0 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.8.0 |
-
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [helm_release.longhorn](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_longhorn_config"></a> [longhorn\_config](#input\_longhorn\_config) | Add-on configuration for Longhorn add-on | `any` | <pre>{<br>  "longhorn_name": "longhorn",<br>  "longhorn_namespace": "longhorn-system"<br>}</pre> | no |
-
-## Outputs
-
-No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
+<!-- TEMPLATE: Please do not remove BEGIN_TF_DOCS/END_TF_DOCS comments below -->
 <!-- BEGIN_TF_DOCS -->
 ### Requirements
 

--- a/modules/longhorn/examples/simple/README.md
+++ b/modules/longhorn/examples/simple/README.md
@@ -8,3 +8,7 @@ This example demonstrates usage of the Longhorn addon module.
 terraform init
 terraform apply
 ```
+
+<!-- TEMPLATE: Please do not remove BEGIN_TF_DOCS/END_TF_DOCS comments below -->
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/modules/metallb/README.md
+++ b/modules/metallb/README.md
@@ -6,6 +6,7 @@ For more details checkout [MetalLB](https://metallb.universe.tf/) docs.
 
 <!-- TEMPLATE: Insert an image here of the infrastructure diagram. You can generate a starting image using instructions found at https://www.terraform.io/docs/cli/commands/graph.html#generating-images -->
 
+<!-- TEMPLATE: Please do not remove BEGIN_TF_DOCS/END_TF_DOCS comments below -->
 <!-- BEGIN_TF_DOCS -->
 ### Requirements
 

--- a/modules/metallb/examples/simple/README.md
+++ b/modules/metallb/examples/simple/README.md
@@ -8,3 +8,7 @@ This example demonstrates usage of the Metallb addon module.
 terraform init
 terraform apply
 ```
+
+<!-- TEMPLATE: Please do not remove BEGIN_TF_DOCS/END_TF_DOCS comments below -->
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/modules/metallb/examples/simple/main.tf
+++ b/modules/metallb/examples/simple/main.tf
@@ -5,7 +5,7 @@ provider "equinix" {
 module "equinix-kubernetes-addons" {
   source = "../../../../"
 
-  equinix_project = var.project
+  equinix_project = var.metal_project_id
   equinix_metro   = "LD"
 
   ssh_host        = var.host

--- a/modules/metallb/examples/simple/main.tf
+++ b/modules/metallb/examples/simple/main.tf
@@ -2,7 +2,7 @@ provider "equinix" {
   auth_token = var.metal_auth_token
 }
 
-module "equinix-kubernetes-addons" {
+module "equinix_kubernetes_addons" {
   source = "../../../../"
 
   equinix_project = var.metal_project_id

--- a/modules/rook/README.md
+++ b/modules/rook/README.md
@@ -10,7 +10,7 @@ For more details checkout [Rook](https://rook.github.io/docs/rook/latest-release
 
 <!-- TEMPLATE: Insert an image here of the infrastructure diagram. You can generate a starting image using instructions found at https://www.terraform.io/docs/cli/commands/graph.html#generating-images -->
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -44,7 +44,7 @@ No modules.
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 <!-- BEGIN_TF_DOCS -->
 ### Requirements

--- a/modules/rook/README.md
+++ b/modules/rook/README.md
@@ -11,7 +11,7 @@ For more details checkout [Rook](https://rook.github.io/docs/rook/latest-release
 <!-- TEMPLATE: Insert an image here of the infrastructure diagram. You can generate a starting image using instructions found at https://www.terraform.io/docs/cli/commands/graph.html#generating-images -->
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
@@ -19,29 +19,29 @@ For more details checkout [Rook](https://rook.github.io/docs/rook/latest-release
 | <a name="requirement_equinix"></a> [equinix](#requirement\_equinix) | >= 1.11.1 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.8.0 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.8.0 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
 | [helm_release.rook](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_rook_config"></a> [rook\_config](#input\_rook\_config) | Add-on configuration for Rook add-on | `any` | <pre>{<br>  "rook_name": "rook_ceph",<br>  "rook_namespace": "rook_ceph"<br>}</pre> | no |
 
-## Outputs
+### Outputs
 
 No outputs.
 <!-- END_TF_DOCS -->

--- a/modules/rook/examples/simple/README.md
+++ b/modules/rook/examples/simple/README.md
@@ -1,7 +1,7 @@
 <!-- TEMPLATE: This file was automatically generated with `generate_addon_structure.sh` and should be modified as necessary -->
 ## Simple Example
 
-This example demonstrates usage of the Equinix Template module.
+This example demonstrates usage of the Rook module.
 
 ## Usage
 

--- a/modules/rook/examples/simple/README.md
+++ b/modules/rook/examples/simple/README.md
@@ -9,3 +9,7 @@ This example demonstrates usage of the Equinix Template module.
 terraform init
 terraform apply
 ```
+
+<!-- TEMPLATE: Please do not remove BEGIN_TF_DOCS/END_TF_DOCS comments below -->
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
Update of all module readme files to use the delimiters required by the gh action for documentation, and remove the pre-commit delimiters, since pre-commit no longer updates the documentation.