### PR TITLE
Fixing typos in add-on structure creation script

### DIFF
--- a/.utils/generate_addon_structure.sh
+++ b/.utils/generate_addon_structure.sh
@@ -99,7 +99,7 @@ function override_template(){
 }
 
 function replace_text_in_addon(){
-    grep -rl "${1}" ./$ADDON_DIR/ | xargs sed -i "" "s|${1}|${2}|g"
+    grep -rl "${1}" ./$ADDON_DIR/ | xargs sed -i "s|${1}|${2}|g"
 }
 
 function move_template(){
@@ -170,7 +170,7 @@ EOT
 
 #sanitize vars
 CAPITALIZED_ADDON_NAME=`echo ${ADDON_NAME:0:1} | tr  '[a-z]' '[A-Z]'`${ADDON_NAME:1}
-ADDON_NAME=$(echo $ADDON_NAME | tr '[- ]' '_' | tr -dc '[:alnum:]_' | tr '[:upper:]' '[:lower:]')
+ADDON_NAME=$(echo $ADDON_NAME | tr '[-]' '_' | tr -dc '[:alnum:]_' | tr '[:upper:]' '[:lower:]')
 ADDON_DIR=$(echo $ADDON_NAME | tr '_' '-')
 
 echo "Checking if ${ADDON_DIR} addon already exists..."


### PR DESCRIPTION
Structure creation script was failing with below errors, it worked fine after fixing typos. 
No major changes, I just did what had to do get it working.

Errors : 

tr: range-endpoints of '[- ' are in reverse collating sequence order

Checking if  addon already exists...

After fixing above error, got below one.

Using latest Equinix terraform provider version 1.11.1

sed: can't read s|{EQUINIX_PROVIDER_VERSION}|1.11.1|g: No such file or directory