### PR TITLE
Add provider meta module_name in Equinix Metal TF configs

### DIFF
--- a/modules/longhorn/examples/simple/versions.tf
+++ b/modules/longhorn/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     equinix = {
       source  = "equinix/equinix"
-      version = ">= 1.11.1"
+      version = "~> 1.14"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/portworx/examples/simple/versions.tf
+++ b/modules/portworx/examples/simple/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     equinix = {
       source  = "equinix/equinix"
-      version = ">= 1.11.1"
+      version = "~> 1.14"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,13 @@
 terraform {
   required_version = ">= 1.0.0"
-
+  provider_meta "equinix" {
+    # Set the name of the module below
+    module_name = "equinix-kubernetes-addons"
+  }
   required_providers {
     equinix = {
       source  = "equinix/equinix"
-      version = ">= 1.11.1"
+      version = "~> 1.14"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
What this PR does / why we need it:
It allows Vendor to declare the metadata fields. It adds provider meta module_name in Equinix Metal TF configs

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

Related to https://github.com/equinix/terraform-provider-equinix/issues/252