### PR TITLE
fix: remove requirement for unused template provider

### DIFF
--- a/modules/portworx-data-services/versions.tf
+++ b/modules/portworx-data-services/versions.tf
@@ -17,7 +17,6 @@ terraform {
       version = ">= 1.11.1"
     }
     http       = ">=3.1.0"
-    template   = ">= 2.0"
     local      = ">= 2.0"
     external   = ">=2.0"
     null       = ">=3.0"

--- a/modules/portworx/versions.tf
+++ b/modules/portworx/versions.tf
@@ -16,7 +16,6 @@ terraform {
       source  = "equinix/equinix"
       version = ">= 1.11.1"
     }
-    template = ">= 2.0"
     local    = ">= 2.0"
     external = ">=2.0"
     null     = ">=3.0"


### PR DESCRIPTION
The portworx and portworx-data-services modules declare a requirement for the (deprecated) template provider, but they do not include any resources from that provider.

The provider requirement makes it impossible to init a terraform config that uses this module on an ARM-based Mac, because the template provider was deprecated before that platform existed, so there is no compatible build of that provider.